### PR TITLE
populate the Source and ThreadId event properties from the Clef data

### DIFF
--- a/Analogy.LogViewer.Serilog.UnitTests/Analogy.LogViewer.Serilog.UnitTests.csproj
+++ b/Analogy.LogViewer.Serilog.UnitTests/Analogy.LogViewer.Serilog.UnitTests.csproj
@@ -65,6 +65,9 @@
     <None Include="ClefExample1.clef">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="SourceContextTest.clef">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="testJson.clef">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Analogy.LogViewer.Serilog.UnitTests/ClefTests.cs
+++ b/Analogy.LogViewer.Serilog.UnitTests/ClefTests.cs
@@ -18,5 +18,31 @@ namespace Analogy.LogViewer.Serilog.UnitTests
             var messages = await p.Process(fileName, cts.Token, forTesting);
             Assert.IsTrue(messages.Count() == 4);
         }
+
+        // Test reading the (optional) source context
+        [TestMethod]
+        public async Task SourceContextTest()
+        {
+            ClefParser p = new ClefParser();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            string fileName = @"SourceContextTest.clef";
+            MessageHandlerForTesting forTesting = new MessageHandlerForTesting();
+            
+            var messages = await p.Process(fileName, cts.Token, forTesting);
+            
+            Assert.AreEqual(2, messages.Count());
+
+            // The first event doesn't have a source context
+            var firstEvent = messages.ElementAt(0);
+            Assert.AreEqual("Hello, Serilog!", firstEvent.Text);
+            Assert.AreEqual(string.Empty, firstEvent.Source);
+            Assert.AreEqual(1, firstEvent.Thread);
+
+            // The second event should have a source context
+            var secondEvent = messages.ElementAt(1);
+            Assert.AreEqual("Contextual Log", secondEvent.Text);
+            Assert.AreEqual("SerilogLogging.Program", secondEvent.Source);
+            Assert.AreEqual(1, secondEvent.Thread);
+        }
     }
 }

--- a/Analogy.LogViewer.Serilog.UnitTests/SourceContextTest.clef
+++ b/Analogy.LogViewer.Serilog.UnitTests/SourceContextTest.clef
@@ -1,0 +1,2 @@
+{"@t":"2020-06-18T18:03:19.2248275Z","@mt":"Hello, Serilog!","ThreadId":1}
+{"@t":"2020-06-18T18:03:19.3586879Z","@mt":"Contextual Log","SourceContext":"SerilogLogging.Program","ThreadId":1}

--- a/Analogy.LogViewer.Serilog/ClefParser.cs
+++ b/Analogy.LogViewer.Serilog/ClefParser.cs
@@ -56,6 +56,34 @@ namespace Analogy.LogViewer.Serilog
 
                                 m.Date = evt.Timestamp.DateTime;
                                 m.Text = AnalogySink.output;
+
+                                if (evt.Properties.TryGetValue(global::Serilog.Core.Constants.SourceContextPropertyName, out var sourceContext))
+                                {
+                                    if (sourceContext is ScalarValue scalarValue && scalarValue.Value is string sourceContextString)
+                                    {
+                                        m.Source = sourceContextString;
+                                    }
+                                    else
+                                    {
+                                        m.Source = sourceContext.ToString();
+                                    }
+                                }
+
+                                if (evt.Properties.TryGetValue("ThreadId", out var threadId))
+                                {
+                                    if (threadId is ScalarValue scalarValue)
+                                    {
+                                        if (scalarValue.Value is int intValue)
+                                        {
+                                            m.Thread = intValue;
+                                        }
+                                        else if (scalarValue.Value is long longValue && longValue <= int.MaxValue)
+                                        {
+                                            m.Thread = (int)longValue;
+                                        }
+                                    }
+                                }
+
                                 parsedMessages.Add(m);
                             }
 


### PR DESCRIPTION
Populate the Source and Thread fields from the ```SourceContext``` and ```ThreadId``` properties in the Clef data, if present (```SourceContext``` is a standard Serilog property added when loggers are created with Log.ForContext, whereas ```ThreadId``` is added by [Serilog.Enrichers.Thread](https://github.com/serilog/serilog-enrichers-thread).

I started off with the simple approach of 

```c#
m.Source = sourceContext.ToString();
```

but then it turned out that that gives you a value surrounded by quotation marks, which I don't think is what's wanted, hence the attempt to unwrap it from a ScalarValue.
i don't think the value should be anything other than a string, so I don't know how much effort it's worth making to handle anything different?

Ditto with the threadId - you could maybe try to parse an integer value out of the string representation directly, but I don't know if there is a need.

Note: I created SourceContextTest.clef by changing the SerilogLogging project in the repo to write in compact json format, for reference.

refs #7