### PR TITLE
changed MinimumLevel for Serilog sink to Verbose

### DIFF
--- a/Analogy.LogViewer.Serilog/Parsers/CompactJsonFormatParser.cs
+++ b/Analogy.LogViewer.Serilog/Parsers/CompactJsonFormatParser.cs
@@ -27,6 +27,7 @@ namespace Analogy.LogViewer.Serilog
                 try
                 {
                     using (var analogy = new LoggerConfiguration()
+                        .MinimumLevel.Verbose()
                         .WriteTo.Analogy()
                         .CreateLogger())
                     {


### PR DESCRIPTION
Verbose messages from log files are not processed with AnalogySink, and all AnologyLogMessage with that level will have text from last nonVerbose message.

Problem is with default message level in Serilog since it's "Debug". Any message with lower levels are not sent to sink