### PR TITLE
🐛 Removing archive from SupportFormats as it is supported directly by…

### DIFF
--- a/Analogy.LogViewer.Serilog.UnitTests/CompactJsonFormatTests.cs
+++ b/Analogy.LogViewer.Serilog.UnitTests/CompactJsonFormatTests.cs
@@ -17,7 +17,7 @@ namespace Analogy.LogViewer.Serilog.UnitTests
         [DataRow("CompactJsonFormat.clef",4, "2016-10-12T04:46:58.0554314Z")]
         [DataRow("CompactJsonFormatSourceContextTest.clef",2, "2020-06-18T18:03:19.2248275Z")]
         [DataRow("CompactJsonFormatTestColumns.clef",4, "2020-06-26T14:21:34.7233612Z")]
-        [DataRow("CompactJsonFormat.gz",4, "2016-10-12T04:46:58.0554314Z")]
+       // [DataRow("CompactJsonFormat.gz",4, "2016-10-12T04:46:58.0554314Z")]
         public async Task OfflineProviderParserTimestampTest(string fileName,int numberOfMessages,string datetimeToParse)
         {
             OfflineDataProvider parser = new OfflineDataProvider();

--- a/Analogy.LogViewer.Serilog.UnitTests/CompactJsonFormatTests.cs
+++ b/Analogy.LogViewer.Serilog.UnitTests/CompactJsonFormatTests.cs
@@ -1,7 +1,9 @@
 ﻿using Analogy.LogViewer.Serilog.DataTypes;
 using Analogy.LogViewer.Serilog.IAnalogy;
+using Analogy.LogViewer.Serilog.Managers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -17,10 +19,11 @@ namespace Analogy.LogViewer.Serilog.UnitTests
         [DataRow("CompactJsonFormat.clef",4, "2016-10-12T04:46:58.0554314Z")]
         [DataRow("CompactJsonFormatSourceContextTest.clef",2, "2020-06-18T18:03:19.2248275Z")]
         [DataRow("CompactJsonFormatTestColumns.clef",4, "2020-06-26T14:21:34.7233612Z")]
-       // [DataRow("CompactJsonFormat.gz",4, "2016-10-12T04:46:58.0554314Z")]
+        [DataRow("CompactJsonFormat.gz",4, "2016-10-12T04:46:58.0554314Z")]
         public async Task OfflineProviderParserTimestampTest(string fileName,int numberOfMessages,string datetimeToParse)
         {
             OfflineDataProvider parser = new OfflineDataProvider();
+            UserSettingsManager.UserSettings.Settings.SupportFormats= new List<string> { "*.Clef", "*.log", "*.gz", "*.zip" };
             CancellationTokenSource cts = new CancellationTokenSource();
             string file = Path.Combine(Folder, "log files", fileName);
             MessageHandlerForTesting forTesting = new MessageHandlerForTesting();

--- a/Analogy.LogViewer.Serilog/SerilogSettings.cs
+++ b/Analogy.LogViewer.Serilog/SerilogSettings.cs
@@ -22,7 +22,7 @@ namespace Analogy.LogViewer.Serilog
             Directory = string.Empty;
             IgnoredAttributes = new List<string>() { "N" };
             FileOpenDialogFilters = "All Supported formats (*.Clef;*.log;*.gz)|*.clef;*.log;*.gz;*.zip|Clef format (*.clef)|*.clef|Plain log text file (*.log)|*.log|GZIP file (*.gz)|*.gz|ZIP file (*.zip)|*.zip";
-            SupportFormats = new List<string> { "*.Clef", "*.log", "*.gz" , "*.zip"};
+            SupportFormats = new List<string> { "*.Clef", "*.log"};
         }
 
 


### PR DESCRIPTION
… FileProcessor

I misunderstood the role of SupportFormats, archives should not anymore be supported by dataProvider (as it is done in FileProcessor), but FileOpenDialogFilters should list archives extensions.